### PR TITLE
docs: Fix simple typo, suchs -> such

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Depending on the purpose of SDK's service and usage — common shared traits are
 The widely adopted good practice, is to write SDK with vanilla JavaScript. 
 Languages compiling to JavaScript such as LiveScript, CoffeeScript, TypeScript and others are **not** recommended.
 
-It is also recommended **not** to use libraries suchs as jQuery in SDK development. 
+It is also recommended **not** to use libraries such as jQuery in SDK development. 
 The exception is of course when it is really important. There are also other jQuery-like libraries, zepto.js _etc_ to choose from, for the DOM manipulation purposes.
 
 In event of HTTP [ajax request](#request) requirements — there are native equivalent such as `window.fetch`. It is light-weight, supported in ever growing platforms. 


### PR DESCRIPTION
There is a small typo in README.md.

Should read `such` rather than `suchs`.

